### PR TITLE
Make bootstrap.zip accessible via GET

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var express = require('express')
   , zip     = require('node-native-zip')
   , app     = express.createServer()
   , types   = {}
+  , downloadHandler
 
 types.img = require('./lib/img')
 types.js  = require('./lib/js')
@@ -49,19 +50,24 @@ app.get('/', function (req, res) {
   res.send('Bootstrap Server - w/cache. <3');
 })
 
-app.post('/', function(req, res) {
+downloadHandler = function downloadHandler(req, res) {
   var dist    = []
     , started = 0
     , params  = {}
     , archive = new zip()
 
-  params.js   = req.body.js   && JSON.parse(req.body.js)
-  params.css  = req.body.css  && JSON.parse(req.body.css)
-  params.img  = req.body.img  && JSON.parse(req.body.img)
-  params.vars = req.body.vars && JSON.parse(req.body.vars)
+  params.js   = req.query.js || req.body.js
+  params.css  = req.query.css || req.body.css
+  params.img  = req.query.img || req.body.img
+  params.vars = req.query.vars || req.body.vars
+
+  Object.keys(params).forEach(function (type) {
+    if (!params[type] || params[type].length === 0) return
+    params[type] = JSON.parse(params[type])
+  })
 
   Object.keys(types).forEach(function (type) {
-    if (!params[type] || !params[type].length) return
+    if (!params[type] || params[type].length === 0) return
     types[type](params, complete)
   })
 
@@ -71,6 +77,9 @@ app.post('/', function(req, res) {
 
   res.attachment('bootstrap.zip')
   res.send(archive.toBuffer())
-})
+}
+
+app.post('/', downloadHandler)
+app.get('/bootstrap.zip', downloadHandler)
 
 app.listen(process.env.PORT || 3000)

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
     "name": "bootstrap-server"
   , "description": "a build tool for bootstrap"
-  , "version": "1.0.0"
+  , "version": "1.0.1"
   , "engines": { "node": "0.6.20" }
   , "main": "web.js"
   , "dependencies": {
-      "express": "2.5.5"
+      "express": "2.5.x"
     , "uglify-js": "1.2.4"
     , "less": "1.3.3"
     , "node-native-zip": "1.0.1"


### PR DESCRIPTION
Hey -

This is a prerequisite for twitter/bootstrap#1487 and enables a GET request to /bootstrap.zip?js=foo&css=bar etc to provide the zip file.

This is a replacement for https://github.com/twitter/bootstrap-server/pull/2 which I inadvertently closed.

Thanks!
