### PR TITLE
add possible namespacing for less/css

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,10 +55,11 @@ app.post('/', function(req, res) {
     , params  = {}
     , archive = new zip()
 
-  params.js   = req.body.js   && JSON.parse(req.body.js)
-  params.css  = req.body.css  && JSON.parse(req.body.css)
-  params.img  = req.body.img  && JSON.parse(req.body.img)
-  params.vars = req.body.vars && JSON.parse(req.body.vars)
+  params.js     = req.body.js   && JSON.parse(req.body.js)
+  params.css    = req.body.css  && JSON.parse(req.body.css)
+  params.img    = req.body.img  && JSON.parse(req.body.img)
+  params.vars   = req.body.vars && JSON.parse(req.body.vars)
+  params.custom = req.body.custom && JSON.parse(req.body.custom)
 
   Object.keys(types).forEach(function (type) {
     if (!params[type] || !params[type].length) return

--- a/lib/css.js
+++ b/lib/css.js
@@ -135,7 +135,13 @@ function css(params, callback) {
   result += CACHE['mixins.less']
 
   params.css.forEach(function (filename) {
+    if (params.custom && params.custom.namespaceCssClass) {
+      result += params.custom.namespaceCssClass + ' {'
+    }
     result += CACHE[filename]
+    if (params.custom && params.custom.namespaceCssClass) {
+      result += '}'
+    }
   })
 
   result = result.replace(/@import[^\n]*/gi, '') //strip any imports


### PR DESCRIPTION
This would allow to have an input field for a css class on the `customize.html` of bootstrap and would add namespaces to the generates CSS like this:

```
.my-custom-ns article,
.my-custom-ns aside,
.my-custom-ns details,
.my-custom-ns figcaption,
.my-custom-ns figure,
.my-custom-ns footer,
.my-custom-ns header,
.my-custom-ns hgroup,
.my-custom-ns nav,
.my-custom-ns section {
  display: block;
}
```
